### PR TITLE
Add system-overrides-path.d for prioritizing override binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ symlinks = .bashrc \
 symdirs = .bash.d \
 	.xmonad \
 	.opt \
+	.local/system-overrides-path.d \
 	.config/autorandr \
 	.local/share/urxvt-scripts \
 	.local/share/rofi/themes \

--- a/dot.bashrc
+++ b/dot.bashrc
@@ -197,13 +197,3 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     unset _1password_socket
 fi
 
-# System path overrides: binaries symlinked into this directory take precedence
-# over system/Homebrew versions (e.g. a modern bash over macOS bash 3.2).
-# Prepended last (and deduped) so macOS path_helper, mise and conda cannot push
-# it behind /usr/bin or /bin.
-system_overrides_dir="$HOME/.local/system-overrides-path.d"
-if [ -d "$system_overrides_dir" ]; then
-    PATH="$system_overrides_dir:${PATH//$system_overrides_dir:/}"
-    export PATH
-fi
-unset system_overrides_dir

--- a/dot.bashrc
+++ b/dot.bashrc
@@ -196,3 +196,14 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     fi
     unset _1password_socket
 fi
+
+# System path overrides: binaries symlinked into this directory take precedence
+# over system/Homebrew versions (e.g. a modern bash over macOS bash 3.2).
+# Prepended last (and deduped) so macOS path_helper, mise and conda cannot push
+# it behind /usr/bin or /bin.
+system_overrides_dir="$HOME/.local/system-overrides-path.d"
+if [ -d "$system_overrides_dir" ]; then
+    PATH="$system_overrides_dir:${PATH//$system_overrides_dir:/}"
+    export PATH
+fi
+unset system_overrides_dir

--- a/dot.bashrc-darwin
+++ b/dot.bashrc-darwin
@@ -26,3 +26,13 @@ alias grep='grep --color=auto'
 alias fgrep='fgrep --color=auto'
 alias egrep='egrep --color=auto'
 
+# System path overrides: binaries symlinked into this directory take precedence
+# over system/Homebrew versions (e.g. a modern bash over macOS bash 3.2).
+# Prepended last (and deduped) so macOS path_helper, mise and conda cannot push
+# it behind /usr/bin or /bin.
+system_overrides_dir="$HOME/.local/system-overrides-path.d"
+if [ -d "$system_overrides_dir" ]; then
+    PATH="$system_overrides_dir:${PATH//$system_overrides_dir:/}"
+    export PATH
+fi
+unset system_overrides_dir

--- a/dot.local/system-overrides-path.d/bash
+++ b/dot.local/system-overrides-path.d/bash
@@ -1,0 +1,1 @@
+/opt/homebrew/bin/bash


### PR DESCRIPTION
## What

Introduce `~/.local/system-overrides-path.d`, a directory whose contents are symlinked binaries that should take precedence over system/Homebrew versions (e.g. a modern bash over macOS's bundled bash 3.2).

## Why

On macOS, `/usr/bin/env bash` and `which bash` were resolving to `/bin/bash` (3.2.57) even though Homebrew bash 5.x is installed and is the login shell. The root cause is macOS `path_helper`, which always lists `/etc/paths` (system dirs like `/usr/bin`, `/bin`) first and appends `/etc/paths.d/*` after — so routing overrides through `pathrc` → `/etc/paths.d/norrs-dotfiles` can never win. An override directory has to be prepended in the interactive rc, after `path_helper`/`mise`/`conda` have run.

## Changes

- **`dot.bashrc`**: prepend `~/.local/system-overrides-path.d` to `PATH` (with dedup) at the very end, so `path_helper`, `mise` and `conda` cannot push it behind `/usr/bin` or `/bin`.
- **`Makefile`**: add `.local/system-overrides-path.d` to `symdirs` so `make install` links it into `~/.local`.
- **`dot.local/system-overrides-path.d/bash`**: seed symlink → `/opt/homebrew/bin/bash`.

## Adding future overrides

Drop a symlink into `dot.local/system-overrides-path.d/` and commit it, e.g.:

    ln -sf /opt/homebrew/bin/<tool> dot.local/system-overrides-path.d/<tool>

## Notes

- The committed `bash` symlink uses the absolute macOS path `/opt/homebrew/bin/bash`; on Linux it will be a dangling (harmless) link.
- An equivalent prepend block was added to `~/.zshrc` locally, but `~/.zshrc` is not tracked in this repo so it is not part of this PR.

## Verification

    # bash login
    which bash        # -> ~/.local/system-overrides-path.d/bash
    /usr/bin/env bash -c 'echo $BASH_VERSION'   # -> 5.3.9

    # zsh login
    which bash        # -> ~/.local/system-overrides-path.d/bash

